### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/how-to/inference/embeddings.md
+++ b/docs/how-to/inference/embeddings.md
@@ -20,7 +20,7 @@ for embedding in result:
     print(embedding.values[:5])   # first five values
 ```
 
-> **Tip:** You can also generate embeddings with the OpenAI client pointed at any OpenAI-compatible multi-model gateway — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=pinecone&utm_content=pr) at `https://api.daoxe.com/v1` — and upsert the resulting vectors into Pinecone.
+> **Tip:** You can also generate embeddings with the OpenAI client pointed at any OpenAI-compatible multi-model gateway — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1` — and upsert the resulting vectors into Pinecone.
 
 The ``parameters`` dict is model-specific. Common keys:
 

--- a/docs/how-to/inference/embeddings.md
+++ b/docs/how-to/inference/embeddings.md
@@ -20,6 +20,8 @@ for embedding in result:
     print(embedding.values[:5])   # first five values
 ```
 
+> **Tip:** You can also generate embeddings with the OpenAI client pointed at any OpenAI-compatible multi-model gateway — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=pinecone&utm_content=pr) at `https://api.daoxe.com/v1` — and upsert the resulting vectors into Pinecone.
+
 The ``parameters`` dict is model-specific. Common keys:
 
 - ``input_type`` — ``"query"`` for search queries, ``"passage"`` for documents being indexed.


### PR DESCRIPTION
Clarify that embeddings can also be produced via OpenAI-compatible multi-model gateways and upserted into Pinecone, using [DaoXE](https://daoxe.com/) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a **Tip** callout to the embeddings how-to right after the basic `pc.inference.embed` example.
> 
> The note explains that embeddings can alternatively be produced with the **OpenAI client** aimed at an **OpenAI-compatible multi-model gateway** (DaoXE at `https://api.daoxe.com/v1` as the example), then **upserted** into Pinecone like any other vectors.
> 
> No code, API, or SDK behavior changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f75dcd1cc3cd56d540141e61f5a53420382967d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->