### PR TITLE
Add Windows ARM64 build

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -185,6 +185,9 @@ jobs:
           # Windows x86_64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          # Windows arm64
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -408,9 +411,9 @@ jobs:
           whl_count=$(ls dist/*.whl 2>/dev/null | wc -l)
           sdist_count=$(ls dist/*.tar.gz 2>/dev/null | wc -l)
           echo "Wheels: $whl_count, Sdists: $sdist_count"
-          # 7 platforms × 1 abi3 wheel (cp310-abi3, covers Python 3.10+) = 7 wheels
-          if [ "$whl_count" -lt 7 ]; then
-            echo "::error::expected at least 7 wheels but got $whl_count — one or more matrix legs may be missing"
+          # 8 platforms × 1 abi3 wheel (cp310-abi3, covers Python 3.10+) = 8 wheels
+          if [ "$whl_count" -lt 8 ]; then
+            echo "::error::expected at least 8 wheels but got $whl_count — one or more matrix legs may be missing"
             exit 1
           fi
           if [ "$sdist_count" -lt 1 ]; then

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -315,6 +315,8 @@ jobs:
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -528,9 +530,9 @@ jobs:
           whl_count=$(ls dist/*.whl 2>/dev/null | wc -l)
           sdist_count=$(ls dist/*.tar.gz 2>/dev/null | wc -l)
           echo "Wheels: ${whl_count}, sdist: ${sdist_count}"
-          # 7 platforms × 1 abi3 wheel = 7
-          if [ "$whl_count" -lt 7 ]; then
-            echo "::error::expected at least 7 wheels, got ${whl_count}"
+          # 8 platforms × 1 abi3 wheel = 8
+          if [ "$whl_count" -lt 8 ]; then
+            echo "::error::expected at least 8 wheels, got ${whl_count}"
             exit 1
           fi
           if [ "$sdist_count" -lt 1 ]; then

--- a/.github/workflows/release-rc.yaml
+++ b/.github/workflows/release-rc.yaml
@@ -304,6 +304,8 @@ jobs:
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -514,9 +516,9 @@ jobs:
           whl_count=$(ls dist/*.whl 2>/dev/null | wc -l)
           sdist_count=$(ls dist/*.tar.gz 2>/dev/null | wc -l)
           echo "Wheels: ${whl_count}, sdist: ${sdist_count}"
-          # 7 platforms × 1 abi3 wheel = 7
-          if [ "$whl_count" -lt 7 ]; then
-            echo "::error::expected at least 7 wheels, got ${whl_count}"
+          # 8 platforms × 1 abi3 wheel = 8
+          if [ "$whl_count" -lt 8 ]; then
+            echo "::error::expected at least 8 wheels, got ${whl_count}"
             exit 1
           fi
           if [ "$sdist_count" -lt 1 ]; then

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -485,6 +485,8 @@ jobs:
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -36,8 +36,8 @@ There are no user-facing extras. `pip install pinecone` gives you the whole SDK:
 The `dev` and `docs` extras exist for working on the SDK itself, not for using it.
 
 Wheels are published for Linux (glibc and musl, x86-64 and arm64), macOS (Intel and
-Apple silicon), and Windows x86-64. Installing from the source distribution instead
-builds the gRPC extension from Rust and needs a Rust toolchain.
+Apple silicon), and Windows (x86-64 and arm64). Installing from the source
+distribution instead builds the gRPC extension from Rust and needs a Rust toolchain.
 
 ## pandas is not installed for you
 


### PR DESCRIPTION
## Problem

The package does not install on Windows ARM64 machines, if build tooling is not installed.

## Solution

As the title says, added Windows ARM64 builds to CI.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI is passing, I did a smoke test on the built wheels on my Windows ARM64 machine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; no runtime or auth changes. Release jobs could fail if the new runner leg is flaky, but that does not affect already-shipped packages.
> 
> **Overview**
> Adds **Windows on ARM64** (`aarch64-pc-windows-msvc`) to the cross-platform wheel build matrix so published wheels install on Windows ARM64 without a local Rust build.
> 
> The new leg runs on **`windows-11-arm`** in **dev publish**, **RC/prod release**, and **release readiness** workflows—the same maturin targets as the existing Windows x64 job. Collect/publish validation now expects **8** abi3 wheels (was **7**) so a missing ARM64 artifact fails the pipeline.
> 
> **Installation** docs now state that Windows wheels cover **x86-64 and arm64**, matching what CI ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e6d82661ba188952db9e25dea46c970d3c1869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->